### PR TITLE
feat(bginfo-2016+): use PowerShell's #Requires

### DIFF
--- a/Deploy-BgInfo-WS2016-WS2019-WS2022.ps1
+++ b/Deploy-BgInfo-WS2016-WS2019-WS2022.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 5.1 -RunAsAdministrator
 <#
 .SYNOPSIS
 


### PR DESCRIPTION
Thanks for the great work on this!

I have a suggestion which could make it easier to identify issues relating to the run requirements (i.e. RunAs, PS =>5.1).

Failure to meet the requirements would look like this:
![image](https://user-images.githubusercontent.com/10629864/156021781-01eb9e64-ed94-4430-b334-7438f6623b59.png)

(Using 7.1 to cause failure for this example)

Reference: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_requires?view=powershell-5.1
